### PR TITLE
fix: 여행 일정 기능

### DIFF
--- a/src/core/domain/entities/trip.ts
+++ b/src/core/domain/entities/trip.ts
@@ -16,3 +16,12 @@ export interface CreatedTrip {
   members: string[];
   created_by: string;
 }
+
+export interface UpdatedTrip {
+  title: string;
+  destination: string;
+  start_date?: Date;
+  end_date?: Date;
+  members: string[];
+  created_by: string;
+}

--- a/src/core/domain/entities/user.ts
+++ b/src/core/domain/entities/user.ts
@@ -7,7 +7,6 @@ interface User {
   user_memo: string;
   access_token: string;
   refresh_token: string;
-  trip_history: Array<number>;
 }
 
 export default User;

--- a/src/core/presentation/components/EditTrip/EditTrip.tsx
+++ b/src/core/presentation/components/EditTrip/EditTrip.tsx
@@ -3,17 +3,18 @@ import { Navigate } from 'react-router-dom';
 import { X } from 'lucide-react';
 import DropDown from '@/core/presentation/components/dropDown/DropDown.tsx';
 import Avatar from 'react-avatar';
+import axios from 'axios';
 
 import { CreatedTrip, Trip } from '@/core/domain/entities/trip.ts';
 import User from '@/core/domain/entities/user.ts';
 import { Region, regions, subregions } from '@/core/domain/entities/regions.ts';
+
 import useTripStore from '@/core/presentation/hooks/stores/tripStore.ts';
 import { useAuthStore } from '@/core/presentation/hooks/stores/authStore.ts';
+import { useUserTripStore } from '@/core/presentation/hooks/stores/userTripStore.ts';
 
 import DatePickerComponent from '@/core/presentation/components/datePicker/DatePickerComponent.tsx';
 import SearchInputComponent from '@/core/presentation/components/Search/SearchInputComponent.tsx';
-import { useUserTripStore } from '@/core/presentation/hooks/stores/userTripStore.ts';
-import axios from 'axios';
 
 interface EditTripProps {
   trip: Trip;
@@ -51,12 +52,22 @@ const EditTrip: React.FC<EditTripProps> = ({ trip, onUpdate, onClose }) => {
   const subregionOptions = region ? subregions[region] : [];
 
   const { setUserTripData } = useUserTripStore();
+  const { fetchTripMembers } = useTripStore();
 
   useEffect(() => {
     const initialRegion = determineRegion(trip.destination);
     setRegion(initialRegion);
     setSubregion(trip.destination.split(' ')[1]);
   }, [trip]);
+
+  useEffect(() => {
+    const loadTripMembers = async () => {
+      const members = await fetchTripMembers(trip.members);
+      setMembers(members);
+    };
+
+    loadTripMembers();
+  }, [trip.members]);
 
   // 목적지 구분 (국내/해외)
   const determineRegion = (destination: string): Region => {
@@ -304,8 +315,8 @@ const EditTrip: React.FC<EditTripProps> = ({ trip, onUpdate, onClose }) => {
 
   // logging
   useEffect(() => {
-    // console.log('formData', formData);
-  }, [handleSubmit]);
+    console.log('update formData:', formData);
+  }, [handleSubmit, formData]);
 
   return (
     <div className="w-full h-full bg-white min-h-[600px] flex flex-col">

--- a/src/core/presentation/components/EditTrip/EditTrip.tsx
+++ b/src/core/presentation/components/EditTrip/EditTrip.tsx
@@ -12,6 +12,8 @@ import { useAuthStore } from '@/core/presentation/hooks/stores/authStore.ts';
 
 import DatePickerComponent from '@/core/presentation/components/datePicker/DatePickerComponent.tsx';
 import SearchInputComponent from '@/core/presentation/components/Search/SearchInputComponent.tsx';
+import { useUserTripStore } from '@/core/presentation/hooks/stores/userTripStore.ts';
+import axios from 'axios';
 
 interface EditTripProps {
   trip: Trip;
@@ -47,6 +49,8 @@ const EditTrip: React.FC<EditTripProps> = ({ trip, onUpdate, onClose }) => {
   const [region, setRegion] = useState<Region | ''>('');
   const [subregion, setSubregion] = useState('');
   const subregionOptions = region ? subregions[region] : [];
+
+  const { setUserTripData } = useUserTripStore();
 
   useEffect(() => {
     const initialRegion = determineRegion(trip.destination);
@@ -101,9 +105,17 @@ const EditTrip: React.FC<EditTripProps> = ({ trip, onUpdate, onClose }) => {
   };
 
   // 폼 제출 핸들러.
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     onUpdate(formData);
+
+    // 업데이트 된 데이터 불러오기
+    if (user) {
+      const updatedTripsData = await axios.get(
+        `${import.meta.env.VITE_API_URL}/trips/user/${user.id}`,
+      );
+      setUserTripData(updatedTripsData.data);
+    }
   };
 
   // datePicker 핸들러.

--- a/src/core/presentation/components/Search/SearchInputComponent.stories.tsx
+++ b/src/core/presentation/components/Search/SearchInputComponent.stories.tsx
@@ -32,7 +32,6 @@ const dummyUsers: User[] = [
     user_memo: 'Loves traveling',
     access_token: 'access_token_1',
     refresh_token: 'refresh_token_1',
-    trip_history: [1, 2, 3],
   },
   {
     id: '2',
@@ -43,7 +42,6 @@ const dummyUsers: User[] = [
     user_memo: 'Frequent flyer',
     access_token: 'access_token_2',
     refresh_token: 'refresh_token_2',
-    trip_history: [1],
   },
   {
     id: '3',
@@ -54,7 +52,6 @@ const dummyUsers: User[] = [
     user_memo: 'Adventure seeker',
     access_token: 'access_token_3',
     refresh_token: 'refresh_token_3',
-    trip_history: [2, 3],
   },
 ];
 

--- a/src/core/presentation/components/Search/SearchInputComponent.tsx
+++ b/src/core/presentation/components/Search/SearchInputComponent.tsx
@@ -83,6 +83,16 @@ const SearchInputComponent: React.FC<SearchInputProps> = ({
     handleSearchProps(searchResults);
   }, [searchResults]);
 
+  // logging
+  useEffect(() => {
+    console.log('selectedMembers:', selectedMembers);
+    console.log(
+      'selectedMembersEmails:',
+      selectedMembers.map((m) => m.email),
+    );
+    console.log('options:', options);
+  }, [options, selectedMembers]);
+
   const handleSelectionChange = (selectedValuesArray: string[]) => {
     const selectedUsers = searchResults.filter((user) =>
       selectedValuesArray.includes(user.email),

--- a/src/core/presentation/components/Search/SearchInputComponent.tsx
+++ b/src/core/presentation/components/Search/SearchInputComponent.tsx
@@ -46,9 +46,10 @@ const SearchInputComponent: React.FC<SearchInputProps> = ({
 
       setIsLoading(true);
       try {
-        console.log('debouncedSearchTerms', debouncedSearchTerms);
+        const query = debouncedSearchTerms.join('');
+        console.log('query:', query);
         const response = await axios.get<User[]>(
-          `${apiUrl}/users/emails/${debouncedSearchTerms}`,
+          `${apiUrl}/users/search?query=${encodeURIComponent(query)}`,
         );
         setSearchResults(response.data);
         console.log('SearchResults:', response.data);

--- a/src/core/presentation/components/TripDetail/TripDetail.tsx
+++ b/src/core/presentation/components/TripDetail/TripDetail.tsx
@@ -383,20 +383,36 @@ const TripDetail: React.FC<TripDetailProps> = ({
                     </span>
                   </div>
                   {/* 멤버 아바타 */}
-                  <div className="flex items-center gap-2">
-                    {memberProfiles.map((member, index) => (
-                      <Avatar
-                        key={member.id}
-                        name={member.nickname}
-                        src={member.user_image}
-                        size="32"
-                        round
-                        color={`hsl(${index * 60}, 70%, 85%)`}
-                      />
+                  <div
+                    className="relative h-8"
+                    style={{
+                      width: `${memberProfiles.length > 4 ? 5 * 20 : memberProfiles.length * 20 + 12}px`,
+                    }}
+                  >
+                    {memberProfiles.slice(0, 4).map((member, index) => (
+                      <div
+                        key={member.email}
+                        className="absolute"
+                        style={{ left: `${index * 20}px`, zIndex: 10 - index }} // 겹치게
+                      >
+                        <Avatar
+                          name={member.nickname}
+                          src={member.user_image}
+                          size="32"
+                          round
+                          color={`hsl(${index * 60}, 70%, 85%)`}
+                        />
+                      </div>
                     ))}
-                    {memberProfiles.length > 3 && (
-                      <div className="flex items-center justify-center w-8 h-8 text-sm text-gray-600 bg-gray-100 border-2 border-white rounded-full">
-                        +{memberProfiles.length - 3}
+                    {memberProfiles.length > 4 && (
+                      <div
+                        className="absolute flex items-center justify-center w-8 h-8 text-sm text-gray-600 bg-gray-100 border-2 border-white rounded-full"
+                        style={{
+                          left: `${4 * 20}px`,
+                          zIndex: 11, // 가장 위로
+                        }}
+                      >
+                        +{memberProfiles.length - 4}
                       </div>
                     )}
                   </div>

--- a/src/core/presentation/hooks/stores/tripStore.ts
+++ b/src/core/presentation/hooks/stores/tripStore.ts
@@ -1,13 +1,20 @@
 import { create } from 'zustand';
+import User from '@/core/domain/entities/user.ts';
+import { Trip } from '@/core/domain/entities/trip.ts';
 
 interface TripStore {
+  tripData: Trip | null;
   step: number;
   setStep: (direction: 'next' | 'previous') => void;
+  setTripData: (trip: Trip) => void;
   resetStep: () => void;
+  fetchTripMembers: (emails: string[]) => Promise<User[]>;
+  fetchTrip: (tripId: number) => Promise<Trip | undefined>;
 }
 
 const useTripStore = create<TripStore>((set) => ({
   // get
+  tripData: null,
   step: 1,
 
   // set
@@ -18,6 +25,57 @@ const useTripStore = create<TripStore>((set) => ({
 
   // reset
   resetStep: () => set({ step: 1 }),
+
+  setTripData: (trip: Trip) => {
+    set({ tripData: trip });
+  },
+
+  // 멤버 조회
+  fetchTripMembers: async (emails: string[]) => {
+    if (!emails || emails.length === 0) return [];
+
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_API_URL}/users/emails`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ emails }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error('멤버 정보를 불러오는 데 실패했습니다.');
+      }
+
+      const data: User[] = await response.json();
+      return data;
+    } catch (error) {
+      console.error('fetchTripMembers error', error);
+      return [];
+    }
+  },
+
+  // 여행 조회
+  fetchTrip: async (tripId: number) => {
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_API_URL}/trips/${tripId}`,
+      );
+
+      if (!response.ok) {
+        throw new Error('여행 데이터를 불러오는 데 실패했습니다.');
+      }
+
+      const data: Trip = await response.json();
+      console.log('data:', data);
+      set({ tripData: data });
+      return data;
+    } catch (error) {
+      console.error('여행 데이터 fetch 에러:', error);
+    }
+  },
 }));
 
 export default useTripStore;

--- a/src/core/presentation/hooks/stores/userTripStore.ts
+++ b/src/core/presentation/hooks/stores/userTripStore.ts
@@ -13,7 +13,6 @@ interface UserTripState {
 export const useUserTripStore = create<UserTripState>()((set, get) => ({
   tripData: [],
   setUserTripData: (trips: Trip[]) => {
-
     set({ tripData: trips });
   },
 

--- a/src/core/presentation/pages/EditTripPage.tsx
+++ b/src/core/presentation/pages/EditTripPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { CreatedTrip } from '../../domain/entities/trip.ts';
+import { UpdatedTrip } from '../../domain/entities/trip.ts';
 import { useUserTripEventStore } from '@/core/presentation/hooks/stores/userTripEventStore.ts';
 import { useUserTripStore } from '@/core/presentation/hooks/stores/userTripStore.ts';
 
@@ -26,19 +26,31 @@ export function EditTripPage() {
   }, []);
 
   // 수정하기 핸들러
-  const handleTripUpdate = async (updatedTrip: CreatedTrip) => {
+  const handleTripUpdate = async (updatedTrip: UpdatedTrip) => {
     try {
+      // 날짜 데이터를 ISO 문자열로 변환
+      const payload = {
+        ...updatedTrip,
+        start_date: updatedTrip.start_date?.toISOString(),
+        end_date: updatedTrip.end_date?.toISOString(),
+      };
+
+      console.log('updatedTrip', updatedTrip);
+      console.log('payload', payload);
+
       const response = await fetch(
         `${import.meta.env.VITE_API_URL}/trips/${tripId}`,
         {
-          method: 'PUT',
+          method: 'PATCH',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(updatedTrip),
+          body: JSON.stringify(payload),
         },
       );
+
       if (!response.ok) throw new Error('Failed to update trip');
+
       navigate('/trip-detail');
       resetStep();
     } catch (error) {

--- a/src/core/presentation/pages/EditTripPage.tsx
+++ b/src/core/presentation/pages/EditTripPage.tsx
@@ -2,8 +2,6 @@ import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { UpdatedTrip } from '../../domain/entities/trip.ts';
-import { useUserTripEventStore } from '@/core/presentation/hooks/stores/userTripEventStore.ts';
-import { useUserTripStore } from '@/core/presentation/hooks/stores/userTripStore.ts';
 
 import EditTrip from '@/core/presentation/components/EditTrip/EditTrip.tsx';
 import useTripStore from '@/core/presentation/hooks/stores/tripStore.ts';
@@ -14,10 +12,8 @@ export function EditTripPage() {
   const navigate = useNavigate();
 
   // TripData 상태관리
-  const { selectedTripId } = useUserTripEventStore();
-  const { getSelectedTripById } = useUserTripStore();
-  const trip = getSelectedTripById(selectedTripId!);
-  const { resetStep } = useTripStore();
+  const { resetStep, tripData } = useTripStore();
+  const trip = tripData;
 
   // logging
   useEffect(() => {


### PR DESCRIPTION
Fix
- 추가된 멤버가 많을 때 여행 기간 UI를 침범하는 문제 해결
- Avatar 겹쳐져서 보이게 수정
- 추가된 인원 수 정확하게 표시 (최대 4개 프로필 아바타 표시 추가 인원은 +n 명으로 표시)
- 여행 정보 변경 후 업데이트 된 데이터 표시

Refactor
- 유저 검색 라우트 변경 및 기능 적용
- tripSchedule 타입 변경 (trip_history 제거)
- 여행 조회 시 멤버 정보 따로 요청 (DB 분리)
- Avatar UI 로직 수정